### PR TITLE
Opt out of persisting credentials

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -25,6 +25,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@3a77c29278ae80936b4cb030fefc7d21c96c786f # v1.185.0
         with:


### PR DESCRIPTION
`actions/checkout` uses a default value of `true` for `persist-credentials`, which results in credentials being written to the Git config. This change prevents the credentials from being written.